### PR TITLE
feat: add path security validation and URL whitelisting

### DIFF
--- a/src/core/security.test.ts
+++ b/src/core/security.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFile, mkdir, rm, symlink } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  validateFilePath,
+  validateExternalUrl,
+  validateGitHubRepoUrl,
+  validateGistUrl,
+  SecurityError,
+  createSafePathValidator
+} from './security.js';
+
+describe('Security Module', () => {
+  let testDir: string;
+  let testFile: string;
+
+  beforeEach(async () => {
+    // Create a temporary test directory
+    testDir = join(tmpdir(), `ragist-test-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+    
+    // Create a test file
+    testFile = join(testDir, 'test.txt');
+    await writeFile(testFile, 'test content');
+  });
+
+  afterEach(async () => {
+    // Clean up test directory
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('validateFilePath', () => {
+    it('should allow files within the base directory', async () => {
+      const result = await validateFilePath('test.txt', testDir, ['.']);
+      expect(result).toBe(testFile);
+    });
+
+    it('should reject path traversal attempts', async () => {
+      await expect(
+        validateFilePath('../../../etc/passwd', testDir, ['.'])
+      ).rejects.toThrow(SecurityError);
+      
+      await expect(
+        validateFilePath('../../etc/passwd', testDir, ['.'])
+      ).rejects.toThrow(SecurityError);
+    });
+
+    it('should reject encoded path traversal attempts', async () => {
+      await expect(
+        validateFilePath('..%2F..%2F..%2Fetc%2Fpasswd', testDir, ['.'])
+      ).rejects.toThrow(SecurityError);
+    });
+
+    it('should reject absolute paths to system directories', async () => {
+      await expect(
+        validateFilePath('/etc/passwd', testDir, ['.'])
+      ).rejects.toThrow(SecurityError);
+      
+      await expect(
+        validateFilePath('/root/.bash_history', testDir, ['.'])
+      ).rejects.toThrow(SecurityError);
+      
+      await expect(
+        validateFilePath('/var/log/auth.log', testDir, ['.'])
+      ).rejects.toThrow(SecurityError);
+    });
+
+    it('should handle symbolic links safely', async () => {
+      // Create a symlink pointing outside the safe area
+      const symlinkPath = join(testDir, 'malicious_link');
+      const outsidePath = join(tmpdir(), 'outside_file');
+      
+      await writeFile(outsidePath, 'outside content');
+      await symlink(outsidePath, symlinkPath);
+      
+      await expect(
+        validateFilePath('malicious_link', testDir, ['.'])
+      ).rejects.toThrow(SecurityError);
+      
+      // Clean up
+      await rm(outsidePath, { force: true });
+    });
+
+    it('should allow files in permitted subdirectories', async () => {
+      const subDir = join(testDir, 'docs');
+      await mkdir(subDir);
+      const subFile = join(subDir, 'readme.md');
+      await writeFile(subFile, '# README');
+      
+      const result = await validateFilePath('docs/readme.md', testDir, ['.', './docs']);
+      expect(result).toBe(subFile);
+    });
+
+    it('should reject empty or invalid paths', async () => {
+      await expect(validateFilePath('', testDir)).rejects.toThrow(SecurityError);
+      await expect(validateFilePath(null as any, testDir)).rejects.toThrow(SecurityError);
+      await expect(validateFilePath(undefined as any, testDir)).rejects.toThrow(SecurityError);
+    });
+  });
+
+  describe('validateExternalUrl', () => {
+    it('should allow valid GitHub URLs', () => {
+      expect(() => validateExternalUrl('https://github.com/user/repo')).not.toThrow();
+      expect(() => validateExternalUrl('https://api.github.com/repos/user/repo')).not.toThrow();
+      expect(() => validateExternalUrl('https://gist.github.com/user/abc123')).not.toThrow();
+      expect(() => validateExternalUrl('https://raw.githubusercontent.com/user/repo/main/file.txt')).not.toThrow();
+    });
+
+    it('should reject non-HTTPS URLs', () => {
+      expect(() => validateExternalUrl('http://github.com/user/repo')).toThrow(SecurityError);
+      expect(() => validateExternalUrl('ftp://github.com/user/repo')).toThrow(SecurityError);
+    });
+
+    it('should reject non-allowed domains', () => {
+      expect(() => validateExternalUrl('https://malicious.com/file.txt')).toThrow(SecurityError);
+      expect(() => validateExternalUrl('https://evil.github.com.malicious.com/file')).toThrow(SecurityError);
+      expect(() => validateExternalUrl('https://pastebin.com/raw/abc123')).toThrow(SecurityError);
+    });
+
+    it('should reject invalid URLs', () => {
+      expect(() => validateExternalUrl('not-a-url')).toThrow(SecurityError);
+      expect(() => validateExternalUrl('')).toThrow(SecurityError);
+      expect(() => validateExternalUrl(null as any)).toThrow(SecurityError);
+    });
+  });
+
+  describe('validateGitHubRepoUrl', () => {
+    it('should parse valid GitHub repository URLs', () => {
+      const result = validateGitHubRepoUrl('https://github.com/user/repo');
+      expect(result).toEqual({ owner: 'user', repo: 'repo' });
+      
+      const resultWithGit = validateGitHubRepoUrl('https://github.com/user/repo.git');
+      expect(resultWithGit).toEqual({ owner: 'user', repo: 'repo' });
+    });
+
+    it('should reject non-GitHub URLs', () => {
+      expect(() => validateGitHubRepoUrl('https://gitlab.com/user/repo')).toThrow(SecurityError);
+      expect(() => validateGitHubRepoUrl('https://bitbucket.org/user/repo')).toThrow(SecurityError);
+    });
+
+    it('should reject invalid repository formats', () => {
+      expect(() => validateGitHubRepoUrl('https://github.com/user')).toThrow(SecurityError);
+      expect(() => validateGitHubRepoUrl('https://github.com/')).toThrow(SecurityError);
+      expect(() => validateGitHubRepoUrl('https://github.com')).toThrow(SecurityError);
+    });
+
+    it('should validate owner and repository names', () => {
+      expect(() => validateGitHubRepoUrl('https://github.com/user@evil/repo')).toThrow(SecurityError);
+      expect(() => validateGitHubRepoUrl('https://github.com/user/repo<script>')).toThrow(SecurityError);
+    });
+  });
+
+  describe('validateGistUrl', () => {
+    it('should parse valid Gist URLs', () => {
+      const gistId = validateGistUrl('https://gist.github.com/user/abc123def456');
+      expect(gistId).toBe('abc123def456');
+      
+      const gistId2 = validateGistUrl('https://gist.github.com/username/1234567890abcdef');
+      expect(gistId2).toBe('1234567890abcdef');
+    });
+
+    it('should reject non-Gist URLs', () => {
+      expect(() => validateGistUrl('https://github.com/user/repo')).toThrow(SecurityError);
+      expect(() => validateGistUrl('https://pastebin.com/abc123')).toThrow(SecurityError);
+    });
+
+    it('should reject invalid Gist formats', () => {
+      expect(() => validateGistUrl('https://gist.github.com/user')).toThrow(SecurityError);
+      expect(() => validateGistUrl('https://gist.github.com/user/invalid-gist-id')).toThrow(SecurityError);
+      expect(() => validateGistUrl('https://gist.github.com/user/ABCDEF')).toThrow(SecurityError); // uppercase not allowed
+    });
+  });
+
+  describe('createSafePathValidator', () => {
+    it('should create a validator with custom base directory', async () => {
+      const validator = createSafePathValidator(testDir, ['.']);
+      
+      const result = await validator('test.txt');
+      expect(result).toBe(testFile);
+      
+      await expect(validator('../../../etc/passwd')).rejects.toThrow(SecurityError);
+    });
+
+    it('should work with custom allowed subdirectories', async () => {
+      const subDir = join(testDir, 'allowed');
+      await mkdir(subDir);
+      const subFile = join(subDir, 'file.txt');
+      await writeFile(subFile, 'content');
+      
+      const validator = createSafePathValidator(testDir, ['./allowed']);
+      
+      const result = await validator('allowed/file.txt');
+      expect(result).toBe(subFile);
+      
+      // Should reject files in the base directory since it's not in allowed paths
+      await expect(validator('test.txt')).rejects.toThrow(SecurityError);
+    });
+  });
+
+  describe('SecurityError', () => {
+    it('should create SecurityError with message and code', () => {
+      const error = new SecurityError('Test message', 'TEST_CODE');
+      expect(error.message).toBe('Test message');
+      expect(error.code).toBe('TEST_CODE');
+      expect(error.name).toBe('SecurityError');
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/src/core/security.ts
+++ b/src/core/security.ts
@@ -1,0 +1,265 @@
+import { readlink, realpath, stat } from "node:fs/promises";
+import { resolve, relative, isAbsolute, normalize, join } from "node:path";
+import { cwd } from "node:process";
+
+/**
+ * Security validation errors
+ */
+export class SecurityError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+    this.name = 'SecurityError';
+  }
+}
+
+/**
+ * Allowed domains for external resource access
+ */
+const ALLOWED_DOMAINS = [
+  'gist.github.com',
+  'api.github.com',
+  'github.com',
+  'raw.githubusercontent.com'
+] as const;
+
+/**
+ * Base directories that are considered safe for file access
+ * These are relative to the current working directory
+ */
+const DEFAULT_SAFE_BASE_PATHS = [
+  '.',  // Current directory
+  './docs',
+  './src',
+  './content',
+  './data'
+] as const;
+
+/**
+ * Validates and sanitizes a file path to prevent path traversal attacks
+ * 
+ * @param filePath - The file path to validate
+ * @param baseDir - Optional base directory to restrict access to (defaults to cwd)
+ * @param allowedBasePaths - Optional list of allowed base paths relative to baseDir
+ * @returns The validated and resolved absolute path
+ * @throws SecurityError if the path is unsafe
+ */
+export async function validateFilePath(
+  filePath: string,
+  baseDir: string = cwd(),
+  allowedBasePaths: readonly string[] = DEFAULT_SAFE_BASE_PATHS
+): Promise<string> {
+  if (!filePath || typeof filePath !== 'string') {
+    throw new SecurityError('Invalid file path provided', 'INVALID_PATH');
+  }
+
+  // Normalize and decode the path to handle encoded characters
+  const decodedPath = decodeURIComponent(filePath);
+  const normalizedPath = normalize(decodedPath);
+  
+  // Check for dangerous patterns
+  if (normalizedPath.includes('..')) {
+    throw new SecurityError('Path traversal detected: ".." not allowed', 'PATH_TRAVERSAL');
+  }
+  
+  // Check for absolute paths to sensitive directories
+  if (isAbsolute(normalizedPath)) {
+    const dangerousPaths = ['/etc', '/root', '/home', '/var', '/usr/local', '/sys', '/proc'];
+    if (dangerousPaths.some(dangerous => normalizedPath.startsWith(dangerous))) {
+      throw new SecurityError('Access to system directories is not allowed', 'SYSTEM_PATH_ACCESS');
+    }
+  }
+
+  // Resolve the path relative to the base directory
+  const resolvedBase = resolve(baseDir);
+  const candidatePath = isAbsolute(normalizedPath) 
+    ? normalizedPath 
+    : resolve(resolvedBase, normalizedPath);
+
+  // Get the real path to handle symbolic links
+  let realPath: string;
+  try {
+    realPath = await realpath(candidatePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // File doesn't exist, but we can still validate the path structure
+      realPath = candidatePath;
+    } else {
+      throw new SecurityError(
+        `Failed to resolve path: ${error instanceof Error ? error.message : String(error)}`,
+        'PATH_RESOLUTION_ERROR'
+      );
+    }
+  }
+
+  // Check if the resolved path is within any of the allowed base paths
+  let pathAllowed = false;
+  for (const allowedBase of allowedBasePaths) {
+    const resolvedAllowedBase = resolve(resolvedBase, allowedBase);
+    const relativePath = relative(resolvedAllowedBase, realPath);
+    
+    // Path is allowed if it doesn't start with '..' (meaning it's within the base)
+    // and doesn't contain '..' segments (no traversal)
+    if (!relativePath.startsWith('..') && !relativePath.includes('..')) {
+      pathAllowed = true;
+      break;
+    }
+  }
+
+  if (!pathAllowed) {
+    throw new SecurityError(
+      `File path "${filePath}" is outside allowed directories. Allowed base paths: ${allowedBasePaths.join(', ')}`,
+      'PATH_NOT_ALLOWED'
+    );
+  }
+
+  // Additional check for symbolic links pointing outside allowed paths
+  if (realPath !== candidatePath) {
+    try {
+      const linkTarget = await readlink(candidatePath).catch(() => null);
+      if (linkTarget && isAbsolute(linkTarget)) {
+        // Re-validate the link target
+        await validateFilePath(linkTarget, baseDir, allowedBasePaths);
+      }
+    } catch (error) {
+      // If we can't validate the symlink target, reject it for safety
+      throw new SecurityError(
+        'Symbolic link target validation failed',
+        'SYMLINK_VALIDATION_ERROR'
+      );
+    }
+  }
+
+  return realPath;
+}
+
+/**
+ * Validates that a URL is from an allowed domain
+ * 
+ * @param url - The URL to validate
+ * @returns true if the URL is from an allowed domain
+ * @throws SecurityError if the URL is not allowed
+ */
+export function validateExternalUrl(url: string): void {
+  if (!url || typeof url !== 'string') {
+    throw new SecurityError('Invalid URL provided', 'INVALID_URL');
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    throw new SecurityError('Invalid URL format', 'INVALID_URL_FORMAT');
+  }
+
+  // Only allow HTTPS for external resources
+  if (parsedUrl.protocol !== 'https:') {
+    throw new SecurityError('Only HTTPS URLs are allowed for external resources', 'NON_HTTPS_URL');
+  }
+
+  // Check if the domain is in the allowed list
+  const hostname = parsedUrl.hostname.toLowerCase();
+  const isAllowed = ALLOWED_DOMAINS.some(domain => 
+    hostname === domain || hostname.endsWith(`.${domain}`)
+  );
+
+  if (!isAllowed) {
+    throw new SecurityError(
+      `Domain "${hostname}" is not allowed. Allowed domains: ${ALLOWED_DOMAINS.join(', ')}`,
+      'DOMAIN_NOT_ALLOWED'
+    );
+  }
+}
+
+/**
+ * Validates a GitHub repository URL
+ * 
+ * @param url - The GitHub repository URL to validate
+ * @returns Parsed repository information
+ * @throws SecurityError if the URL is invalid or not allowed
+ */
+export function validateGitHubRepoUrl(url: string): { owner: string; repo: string } {
+  validateExternalUrl(url);
+  
+  const parsedUrl = new URL(url);
+  
+  // Ensure it's a GitHub URL
+  if (!parsedUrl.hostname.endsWith('github.com')) {
+    throw new SecurityError('URL must be a GitHub repository URL', 'NOT_GITHUB_URL');
+  }
+
+  // Parse owner and repository from the path
+  const pathParts = parsedUrl.pathname.split('/').filter(part => part.length > 0);
+  
+  if (pathParts.length < 2) {
+    throw new SecurityError('Invalid GitHub repository URL format', 'INVALID_GITHUB_URL');
+  }
+
+  const [owner, repo] = pathParts;
+  
+  if (!owner || !repo) {
+    throw new SecurityError('Unable to parse owner and repository from URL', 'GITHUB_PARSE_ERROR');
+  }
+
+  // Basic validation for owner and repo names
+  const validNamePattern = /^[a-zA-Z0-9._-]+$/;
+  if (!validNamePattern.test(owner) || !validNamePattern.test(repo)) {
+    throw new SecurityError('Invalid characters in owner or repository name', 'INVALID_GITHUB_NAME');
+  }
+
+  return { 
+    owner, 
+    repo: repo.replace(/\.git$/, '') // Remove .git suffix if present
+  };
+}
+
+/**
+ * Validates a GitHub Gist URL
+ * 
+ * @param url - The Gist URL to validate
+ * @returns The Gist ID
+ * @throws SecurityError if the URL is invalid or not allowed
+ */
+export function validateGistUrl(url: string): string {
+  validateExternalUrl(url);
+  
+  const parsedUrl = new URL(url);
+  
+  // Ensure it's a Gist URL
+  if (parsedUrl.hostname !== 'gist.github.com') {
+    throw new SecurityError('URL must be a GitHub Gist URL', 'NOT_GIST_URL');
+  }
+
+  // Extract Gist ID from the path
+  const gistIdMatch = parsedUrl.pathname.match(/\/[\w-]+\/([a-f0-9]+)/);
+  
+  if (!gistIdMatch || !gistIdMatch[1]) {
+    throw new SecurityError('Invalid Gist URL format', 'INVALID_GIST_URL');
+  }
+
+  const gistId = gistIdMatch[1];
+  
+  // Validate Gist ID format (should be a hex string)
+  if (!/^[a-f0-9]+$/.test(gistId)) {
+    throw new SecurityError('Invalid Gist ID format', 'INVALID_GIST_ID');
+  }
+
+  return gistId;
+}
+
+/**
+ * Create a safe base directory path resolver
+ * 
+ * @param baseDir - Base directory for operations
+ * @param allowedSubPaths - Allowed subdirectories
+ * @returns A function that validates paths within the safe base
+ */
+export function createSafePathValidator(
+  baseDir: string = cwd(),
+  allowedSubPaths: readonly string[] = DEFAULT_SAFE_BASE_PATHS
+) {
+  const resolvedBaseDir = resolve(baseDir);
+  
+  return async (filePath: string): Promise<string> => {
+    return validateFilePath(filePath, resolvedBaseDir, allowedSubPaths);
+  };
+}


### PR DESCRIPTION
## Summary
- Add comprehensive security module to prevent path traversal attacks
- Implement URL whitelisting for GitHub/Gist domains only
- Add file path validation with base directory restrictions
- Prevent symbolic link and URL encoding bypass attacks

## Security Enhancements
- ❌ Blocks `../../../etc/passwd` path traversal attacks
- ❌ Prevents access to system directories like `/etc/`, `/root/`
- ❌ Restricts external URLs to GitHub/Gist domains only
- ❌ Handles URL encoding bypass attempts
- ❌ Validates symbolic link targets

## Test plan
- [ ] Run security test suite to verify path validation
- [ ] Test CLI with malicious path inputs
- [ ] Verify URL whitelisting blocks non-GitHub domains
- [ ] Confirm legitimate file indexing still works

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)