### PR TITLE
feat: improve markdown chunking to preserve heading hierarchy

### DIFF
--- a/src/core/chunk/boundary-aware-chunking.test.ts
+++ b/src/core/chunk/boundary-aware-chunking.test.ts
@@ -46,6 +46,14 @@ Final thoughts and summary.`;
       chunks.forEach((chunk) => {
         expect(chunk.boundary).toBeDefined();
       });
+
+      // h3 "Details" should be included in the h2 "Background" chunk
+      const backgroundChunk = chunks.find(
+        (c) => c.boundary.title === "Background",
+      );
+      expect(backgroundChunk).toBeDefined();
+      expect(backgroundChunk?.content).toContain("### Details");
+      expect(backgroundChunk?.content).toContain("More detailed information.");
     });
 
     it("should handle markdown without headings", () => {
@@ -121,6 +129,65 @@ Another section here.`;
 
       // There should be only one chunk for this simple markdown
       expect(chunks.length).toBe(1);
+    });
+
+    it("should include h3-h6 headings in parent h1/h2 sections", () => {
+      const markdown = `# Main Section
+
+Intro text for main section.
+
+## Subsection
+
+Subsection intro.
+
+### Small Heading 1
+
+Content under small heading 1.
+
+#### Tiny Heading
+
+Tiny content.
+
+### Small Heading 2
+
+Content under small heading 2.
+
+## Another Subsection
+
+Another subsection content.`;
+
+      const chunks = chunkMarkdownByBoundary(markdown, {
+        maxChunkSize: 300,
+        overlap: 50,
+      });
+
+      // Find the "Subsection" chunk
+      const subsectionChunk = chunks.find(
+        (c) => c.boundary.title === "Subsection",
+      );
+      expect(subsectionChunk).toBeDefined();
+
+      // It should contain all h3-h6 content
+      expect(subsectionChunk?.content).toContain("## Subsection");
+      expect(subsectionChunk?.content).toContain("### Small Heading 1");
+      expect(subsectionChunk?.content).toContain(
+        "Content under small heading 1.",
+      );
+      expect(subsectionChunk?.content).toContain("#### Tiny Heading");
+      expect(subsectionChunk?.content).toContain("Tiny content.");
+      expect(subsectionChunk?.content).toContain("### Small Heading 2");
+      expect(subsectionChunk?.content).toContain(
+        "Content under small heading 2.",
+      );
+
+      // The "Another Subsection" should be a separate chunk
+      const anotherSubsectionChunk = chunks.find(
+        (c) => c.boundary.title === "Another Subsection",
+      );
+      expect(anotherSubsectionChunk).toBeDefined();
+      expect(anotherSubsectionChunk?.content).not.toContain(
+        "### Small Heading 1",
+      );
     });
 
     it("should respect maxChunkSize while maintaining boundaries", () => {

--- a/src/core/chunk/boundary-aware-chunking.ts
+++ b/src/core/chunk/boundary-aware-chunking.ts
@@ -102,28 +102,43 @@ function parseMarkdownSections(markdown: string): Array<{
     // Check for headings
     const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
     if (headingMatch) {
-      const newLevel = headingMatch[1]?.length || 1;
+      const headingLevel = headingMatch[1]?.length || 1;
 
-      // Save previous section before starting a new heading
-      if (currentSection) {
-        sections.push({
-          content: currentSection.lines.join("\n"),
-          startOffset: currentSection.startOffset,
-          endOffset: offset - 1,
-          type: currentSection.type,
-          level: currentSection.level,
-          title: currentSection.title,
-        });
+      // Only create new section for h1 and h2
+      if (headingLevel <= 2) {
+        // Save previous section before starting a new heading
+        if (currentSection) {
+          sections.push({
+            content: currentSection.lines.join("\n"),
+            startOffset: currentSection.startOffset,
+            endOffset: offset - 1,
+            type: currentSection.type,
+            level: currentSection.level,
+            title: currentSection.title,
+          });
+        }
+
+        // Start new heading section
+        currentSection = {
+          lines: [line],
+          startOffset: offset,
+          type: "heading",
+          level: headingLevel,
+          title: headingMatch[2],
+        };
+      } else if (currentSection) {
+        // h3-h6: add to current section
+        currentSection.lines.push(line);
+      } else {
+        // No current section, start a new one even for h3-h6
+        currentSection = {
+          lines: [line],
+          startOffset: offset,
+          type: "heading",
+          level: headingLevel,
+          title: headingMatch[2],
+        };
       }
-
-      // Start new heading section
-      currentSection = {
-        lines: [line],
-        startOffset: offset,
-        type: "heading",
-        level: newLevel,
-        title: headingMatch[2],
-      };
     } else if (currentSection && currentSection.type === "heading") {
       // We're in a heading section - add all content to it
       currentSection.lines.push(line);


### PR DESCRIPTION
Modify parseMarkdownSections to only create new chunks for h1 and h2 headings.
h3-h6 headings now remain within their parent h1/h2 sections instead of
creating separate chunks, which improves context preservation.

Changes:
- Only h1 and h2 headings create new sections
- h3-h6 headings are included in parent sections
- Renamed variable from newLevel to headingLevel for clarity
- Added comprehensive test cases to verify the behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>