### PR TITLE
feat: improve CLI ci:doc command output handling

### DIFF
--- a/src/cli/commands/ci-doc.ts
+++ b/src/cli/commands/ci-doc.ts
@@ -54,18 +54,20 @@ export const handleCIDoc = createReadOnlyCommandHandler<CIDocContext>(
       const finalPaths = options.paths ??
         ciConfig?.documentPaths ?? ["docs/**/*.md", "README.md", "*.md"];
 
-      console.log("📋 Configuration:");
-      console.log(`  - Diff range: ${options.diff}`);
-      console.log(`  - Threshold: ${finalThreshold}`);
-      console.log(`  - Document paths: ${finalPaths.join(", ")}`);
-      console.log(`  - Format: ${options.format}`);
+      console.error("📋 Configuration:");
+      console.error(`  - Diff range: ${options.diff}`);
+      console.error(`  - Threshold: ${finalThreshold}`);
+      console.error(`  - Document paths: ${finalPaths.join(", ")}`);
+      console.error(`  - Format: ${options.format}`);
       if (options.database) {
-        console.log(
+        console.error(
           `  - Database provider: ${options.database.provider ?? "default"}`,
         );
-        console.log(`  - Database path: ${options.database.path ?? "default"}`);
+        console.error(
+          `  - Database path: ${options.database.path ?? "default"}`,
+        );
       }
-      console.log("");
+      console.error("");
     }
 
     try {
@@ -81,7 +83,7 @@ export const handleCIDoc = createReadOnlyCommandHandler<CIDocContext>(
               ? result
               : formatGitHubComment(result, options.threshold ?? 0.7);
           await postToGitHubPR(comment);
-          console.log("✅ Posted analysis to GitHub PR");
+          console.error("✅ Posted analysis to GitHub PR");
         } catch (error) {
           console.error("❌ Failed to post to GitHub PR:", error);
           // Still output the results even if posting fails


### PR DESCRIPTION
- Move verbose configuration messages to stderr to preserve stdout for JSON output
- Move GitHub PR success message to stderr
- Addresses Phase 1 of Issue #117: CLI ci:doc command stdout/stderr output improvements
- Part of Epic #116: Unify CI/CD to use CLI commands

This change ensures that when using --format json, only the actual JSON output goes to stdout, making it safe for programmatic consumption.

🤖 Generated with [Claude Code](https://claude.ai/code)